### PR TITLE
Add GNOME 47/48/49/50 support

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -35,7 +35,10 @@ export default class TouchXExtension extends Extension {
 
                 this._icon.set_gicon(this._oskDisabledIcon);
                 this._settings.set_boolean('lastoskon', false);
-                OsdWindowManager.show(-1, this._oskDisabledIcon, "OSK Disabled");
+                if (OsdWindowManager.showAll)
+                    OsdWindowManager.showAll(this._oskDisabledIcon, "OSK Disabled");
+                else
+                    OsdWindowManager.show(-1, this._oskDisabledIcon, "OSK Disabled");
                 // console.log('Touch mode disabled');
             }
             else
@@ -45,7 +48,10 @@ export default class TouchXExtension extends Extension {
 
                 this._icon.set_gicon(this._oskEnabledIcon);
                 this._settings.set_boolean('lastoskon', true);
-                OsdWindowManager.show(-1, this._oskEnabledIcon, "OSK Enabled");
+                if (OsdWindowManager.showAll)
+                    OsdWindowManager.showAll(this._oskEnabledIcon, "OSK Enabled");
+                else
+                    OsdWindowManager.show(-1, this._oskEnabledIcon, "OSK Enabled");
                 // console.log('Touch mode enabled');
             }
 

--- a/metadata.json
+++ b/metadata.json
@@ -9,9 +9,12 @@
   "name": "Touch X",
   "shell-version": [
     "45",
-    "46"
+    "46",
+    "47",
+    "48",
+    "49"
   ],
   "url": "https://github.com/neuromorph/touchx",
   "uuid": "touchx@neuromorph",
-  "version": 11
+  "version": 12
 }

--- a/metadata.json
+++ b/metadata.json
@@ -12,7 +12,8 @@
     "46",
     "47",
     "48",
-    "49"
+    "49",
+    "50"
   ],
   "url": "https://github.com/neuromorph/touchx",
   "uuid": "touchx@neuromorph",


### PR DESCRIPTION
**GNOME 49: OsdWindowManager API change**

The `show(monitorIndex, icon, label)` method was replaced with three separate methods: `show()`, `showOne()`, and `showAll()`. The two call sites in `_onOskBtnClicked()` that used `show()` to display the OSK toggle OSD on all monitors now use feature detection to call `showAll()` on GNOME 49+ and fall back to the old `show()` for GNOME 45-48.

No other APIs used by the extension were affected across these three releases.

Tested on GNOME 49 and 50. Extension loads cleanly with no errors.